### PR TITLE
Refactoring fill xarray function

### DIFF
--- a/carculator_utils/array.py
+++ b/carculator_utils/array.py
@@ -2,6 +2,7 @@ import itertools
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 from .vehicle_input_parameters import VehicleInputParameters as vip
 
@@ -143,6 +144,7 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
             }
         )
 
+    df = pd.DataFrame.from_dict(data_dict)
     cols = ["powertrain", "size", "value", "year", "parameter"]
     df1 = pd.concat(
         [
@@ -160,7 +162,7 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
     df[cols] = df[cols].apply(lambda x: x.fillna(method="ffill"))
     df.set_index(["size", "powertrain", "parameter", "year", "value"], inplace=True)
     df.dropna(inplace=True)
-    array = df.to_xarray().to_dataarray().drop_vars("variable")[0]
+    array = xr.DataArray.from_series(df["data"])
     array = array.astype("float32")
     array.coords["year"] = array.coords["year"].astype(int)
     array = array.fillna(0.0)
@@ -173,4 +175,4 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
         for param in list_params:
             array.loc[dict(parameter=param, value=param)] *= 1.1
 
-    return ((size_dict, powertrain_dict, parameter_dict, year_dict), array)
+    return (size_dict, powertrain_dict, parameter_dict, year_dict), array

--- a/carculator_utils/array.py
+++ b/carculator_utils/array.py
@@ -1,4 +1,5 @@
 import itertools
+
 import numpy as np
 import pandas as pd
 
@@ -112,10 +113,10 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
             powertrains = list(pwt.intersection(scope["powertrain"]))
             years = list(year.intersection(scope["year"]))
             sizes = list(size.intersection(scope["size"]))
-            if len(sizes)>1 and len(powertrains)>1:
-                pwt_size_couple = np.array(list(itertools.product(powertrains,sizes)))
-                powertrains = pwt_size_couple[:,0]
-                sizes = pwt_size_couple[:,1]
+            if len(sizes) > 1 and len(powertrains) > 1:
+                pwt_size_couple = np.array(list(itertools.product(powertrains, sizes)))
+                powertrains = pwt_size_couple[:, 0]
+                sizes = pwt_size_couple[:, 1]
             data_dict.append(
                 {
                     "size": sizes,
@@ -141,7 +142,7 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
                 "value": 0.0,
             }
         )
-        
+
     cols = ["powertrain", "size", "value", "year", "parameter"]
     df1 = pd.concat(
         [
@@ -157,7 +158,7 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
 
     df = df.drop(cols, axis=1).join(df1.droplevel(1))
     df[cols] = df[cols].apply(lambda x: x.fillna(method="ffill"))
-    df.set_index(["size", "powertrain","parameter",  "year", "value"], inplace=True)
+    df.set_index(["size", "powertrain", "parameter", "year", "value"], inplace=True)
     df.dropna(inplace=True)
     array = df.to_xarray().to_dataarray().drop_vars("variable")[0]
     array = array.astype("float32")
@@ -172,4 +173,4 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
         for param in list_params:
             array.loc[dict(parameter=param, value=param)] *= 1.1
 
-    return ((size_dict, powertrain_dict, parameter_dict, year_dict),array)
+    return ((size_dict, powertrain_dict, parameter_dict, year_dict), array)

--- a/carculator_utils/array.py
+++ b/carculator_utils/array.py
@@ -153,7 +153,7 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
             data["value"] = params
         data_dict.append(data)
 
-    df2 = df = pd.DataFrame.from_dict(data_dict)
+    df = pd.DataFrame.from_dict(data_dict)
     cols = ["powertrain", "size", "value", "year", "parameter"]
     df1 = pd.concat(
         [
@@ -182,4 +182,4 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
         for param in params[1:]:
             array.loc[dict(parameter=param, value=param)] *= 1.1
 
-    return (size_dict, powertrain_dict, parameter_dict, year_dict), array, df2
+    return (size_dict, powertrain_dict, parameter_dict, year_dict), array

--- a/carculator_utils/array.py
+++ b/carculator_utils/array.py
@@ -1,16 +1,12 @@
 import itertools
-
 import numpy as np
 import pandas as pd
-import stats_arrays as sa
-import xarray as xr
 
 from .vehicle_input_parameters import VehicleInputParameters as vip
 
 
 def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope=None):
     """Create an `xarray` labeled array from the sampled input parameters.
-
 
     This function extracts the parameters' names and values contained in the
     `parameters` attribute of the :class:`CarInputParameters` class
@@ -82,59 +78,13 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
     # the number of iterations to perform
     # that is, 1 in `static` mode, or several in `stochastic` mode.
 
-    d = {v: k for k, v in enumerate(scope["size"])}
-
-    if not sensitivity:
-        array = xr.DataArray(
-            np.zeros(
-                (
-                    len(scope["size"]),
-                    len(scope["powertrain"]),
-                    len(input_parameters.parameters),
-                    len(scope["year"]),
-                    input_parameters.iterations or 1,
-                )
-            ),
-            coords=[
-                sorted(scope["size"], key=lambda x: d[x]),
-                scope["powertrain"],
-                input_parameters.parameters,
-                scope["year"],
-                np.arange(input_parameters.iterations or 1),
-            ],
-            dims=["size", "powertrain", "parameter", "year", "value"],
-        ).astype("float32")
-
-    # if the purpose is to do a sensitivity analysis
-    # then the length of the dimensions `value` equals the number of parameters
-    else:
-        params = ["reference"]
-        params.extend([a for a in input_parameters.input_parameters])
-        array = xr.DataArray(
-            np.zeros(
-                (
-                    len(scope["size"]),
-                    len(scope["powertrain"]),
-                    len(input_parameters.parameters),
-                    len(scope["year"]),
-                    len(params),
-                )
-            ),
-            coords=[
-                scope["size"],
-                scope["powertrain"],
-                input_parameters.parameters,
-                scope["year"],
-                params,
-            ],
-            dims=["size", "powertrain", "parameter", "year", "value"],
-        ).astype("float32")
-
     size_dict = {k: i for i, k in enumerate(scope["size"])}
     powertrain_dict = {k: i for i, k in enumerate(scope["powertrain"])}
     year_dict = {k: i for i, k in enumerate(scope["year"])}
     parameter_dict = {k: i for i, k in enumerate(input_parameters.parameters)}
 
+    data_dict = [dict()]
+    parameter_list = set()
     for param in input_parameters:
         pwt = (
             set(input_parameters.metadata[param]["powertrain"])
@@ -153,20 +103,66 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
             if isinstance(input_parameters.metadata[param]["year"], list)
             else set([input_parameters.metadata[param]["year"]])
         )
-
         if (
             pwt.intersection(scope["powertrain"])
             and size.intersection(scope["size"])
             and year.intersection(scope["year"])
         ):
-            array.loc[
-                dict(
-                    powertrain=[p for p in pwt if p in scope["powertrain"]],
-                    size=[s for s in size if s in scope["size"]],
-                    year=[y for y in year if y in scope["year"]],
-                    parameter=input_parameters.metadata[param]["name"],
-                )
-            ] = input_parameters.values[param]
+
+            powertrains = list(pwt.intersection(scope["powertrain"]))
+            years = list(year.intersection(scope["year"]))
+            sizes = list(size.intersection(scope["size"]))
+            if len(sizes)>1 and len(powertrains)>1:
+                pwt_size_couple = np.array(list(itertools.product(powertrains,sizes)))
+                powertrains = pwt_size_couple[:,0]
+                sizes = pwt_size_couple[:,1]
+            data_dict.append(
+                {
+                    "size": sizes,
+                    "powertrain": powertrains,
+                    "parameter": input_parameters.metadata[param]["name"],
+                    "year": years,
+                    "data": input_parameters.values[param],
+                    "value": 0.0,
+                }
+            )
+            parameter_list.add(input_parameters.metadata[param]["name"])
+
+    parameter_diff = parameter_list.symmetric_difference(input_parameters.parameters)
+
+    for param in parameter_diff:
+        data_dict.append(
+            {
+                "powertrain": powertrains,
+                "size": sizes,
+                "year": years,
+                "data": 0.0,
+                "parameter": param,
+                "value": 0.0,
+            }
+        )
+        
+    cols = ["powertrain", "size", "value", "year", "parameter"]
+    df1 = pd.concat(
+        [
+            df[x]
+            .explode()
+            .to_frame()
+            .assign(g=lambda x: x.groupby(level=0).cumcount())
+            .set_index("g", append=True)
+            for x in cols
+        ],
+        axis=1,
+    )
+
+    df = df.drop(cols, axis=1).join(df1.droplevel(1))
+    df[cols] = df[cols].apply(lambda x: x.fillna(method="ffill"))
+    df.set_index(["size", "powertrain","parameter",  "year", "value"], inplace=True)
+    df.dropna(inplace=True)
+    array = df.to_xarray().to_dataarray().drop_vars("variable")[0]
+    array = array.astype("float32")
+    array.coords["year"] = array.coords["year"].astype(int)
+    array = array.fillna(0.0)
 
     if sensitivity:
         # we increase each value by 10%
@@ -176,4 +172,4 @@ def fill_xarray_from_input_parameters(input_parameters, sensitivity=False, scope
         for param in list_params:
             array.loc[dict(parameter=param, value=param)] *= 1.1
 
-    return (size_dict, powertrain_dict, parameter_dict, year_dict), array
+    return ((size_dict, powertrain_dict, parameter_dict, year_dict),array)


### PR DESCRIPTION
The idea here is to drastically improve the efficiency of the function fill_xarray_from_input_parameters
Previously, it iterated through all indexes of an initialized xarray DataArray called array.

What I propose here is to keep the same iterative process but instead of allocating values directly to a DataArray, I append dictionnaries into a list. This list of dictionnary is then used to create a pandas DataFrame. 
For each column of interest (powertrain, size, value, year, parameter), I flatten (through explode function) the lists contained within each row of the dataframe. I use a dummy variable "g" which count elements in each lists for each row of the DataFrame. 
The final DataFrame is built using the flatten dataframe and the corresponding parameters data. NaN are automatically used when a DataFrame is broadcasted. Then I use the ffill method from DataFrame.fillna to replace the NaN by the expected values. 
The columns size, powertrain, parameter, year and value are then passed as index of the DataFrame. 
The resulting DataArray is created from the final pandas Series obtained.

It was not easy to detailled the process here, do not hesite to ask further question if needed.

All tests in carculator_utils, carculator and carculator_trucks seem to work properly. 
