### PR TITLE
Calculation of parameter "energy battery mass" for FCEV

### DIFF
--- a/carculator_utils/model.py
+++ b/carculator_utils/model.py
@@ -472,6 +472,14 @@ class VehicleModel:
             )
 
             self.array.loc[
+                dict(parameter="energy battery mass", powertrain="FCEV")
+            ] = self.array.loc[
+                dict(parameter="battery cell mass", powertrain="FCEV")
+            ] + self.array.loc[
+                dict(parameter="battery BoP mass", powertrain="FCEV")
+            ]
+            
+            self.array.loc[
                 dict(parameter="electric energy stored", powertrain="FCEV")
             ] = (
                 self.array.loc[dict(parameter="battery cell mass", powertrain="FCEV")]


### PR DESCRIPTION
The parameter "energy battery mass" is now required for inventory.py. For all other powertrains, the parameter "energy battery mass" is defined in default_parameters.json.